### PR TITLE
Adjusting server catch call routing

### DIFF
--- a/server/routes/html/HtmlRouter.ts
+++ b/server/routes/html/HtmlRouter.ts
@@ -10,9 +10,7 @@ export class HtmlRouter {
     }
 
     private configureRouter() {
-        this.router.get("/users/register", this.sendClientTheApplication);
-        this.router.get("/users/login", this.sendClientTheApplication);
-        this.router.get("/dashboard/user/:id", this.sendClientTheApplication);
+        this.router.get("*", this.sendClientTheApplication);
     }
 
     private sendClientTheApplication(req: Request, res: Response) {


### PR DESCRIPTION
Nothing big here. If the express server doesn't any match routes typed in the URL bar by the user, it will default to sending them the application. Once the client receives the application, the Angular 4 client side routing system should take over and direct them to the correct place.

Will have to throw in a 404 component to route to in the angular router.